### PR TITLE
Add Range() to iterate over the children of one node

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -87,7 +87,7 @@ func (d *Diff) compare() error {
 		}
 		return nil
 	}
-	err := d.first.Process(firstProcessor)
+	err := d.first.Root().Process(firstProcessor)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func (d *Diff) compare() error {
 		d.paths = append(d.paths, pv.path)
 		return nil
 	}
-	return d.second.Process(secondProcessor)
+	return d.second.Root().Process(secondProcessor)
 }
 
 // EOF

--- a/diff_test.go
+++ b/diff_test.go
@@ -1,0 +1,93 @@
+// Tideland Go Generic JSON Processor - Unit Tests
+//
+// Copyright (C) 2019-2023 Frank Mueller / Tideland / Oldenburg / Germany
+//
+// All rights reserved. Use of this source code is governed
+// by the new BSD license.
+
+package gjp_test
+
+//--------------------
+// IMPORTS
+//--------------------
+
+import (
+	"testing"
+
+	"tideland.dev/go/audit/asserts"
+
+	"tideland.dev/go/gjp"
+)
+
+//--------------------
+// TESTS
+//--------------------
+
+// TestCompare tests comparing two documents.
+func TestCompare(t *testing.T) {
+	assert := asserts.NewTesting(t, asserts.FailStop)
+	first, _ := createDocument(assert)
+	second := createCompareDocument(assert)
+	firstDoc, err := gjp.Unmarshal(first)
+	assert.NoError(err)
+	secondDoc, err := gjp.Unmarshal(second)
+	assert.NoError(err)
+
+	diff, err := gjp.Compare(first, first)
+	assert.NoError(err)
+	assert.Length(diff.Differences(), 0)
+
+	diff, err = gjp.Compare(first, second)
+	assert.NoError(err)
+	assert.Length(diff.Differences(), 13)
+
+	diff, err = gjp.CompareDocuments(firstDoc, secondDoc)
+	assert.NoError(err)
+	assert.Length(diff.Differences(), 13)
+
+	for _, path := range diff.Differences() {
+		fv, sv := diff.DifferenceAt(path)
+		fvs := fv.AsString("<first undefined>")
+		svs := sv.AsString("<second undefined>")
+		assert.Different(fvs, svs, path)
+	}
+
+	first, err = diff.FirstDocument().MarshalJSON()
+	assert.NoError(err)
+	second, err = diff.SecondDocument().MarshalJSON()
+	assert.NoError(err)
+	diff, err = gjp.Compare(first, second)
+	assert.NoError(err)
+	assert.Length(diff.Differences(), 13)
+
+	// Special case of empty arrays, objects, and null.
+	first = []byte(`{}`)
+	second = []byte(`{"a":[],"b":{},"c":null}`)
+
+	sdocParsed, err := gjp.Unmarshal(second)
+	assert.NoError(err)
+	sdocMarshalled, err := sdocParsed.MarshalJSON()
+	assert.NoError(err)
+	assert.Equal(string(sdocMarshalled), string(second))
+
+	diff, err = gjp.Compare(first, second)
+	assert.NoError(err)
+	assert.Length(diff.Differences(), 4)
+
+	first = []byte(`[]`)
+	diff, err = gjp.Compare(first, second)
+	assert.NoError(err)
+	assert.Length(diff.Differences(), 4)
+
+	first = []byte(`["A", "B", "C"]`)
+	diff, err = gjp.Compare(first, second)
+	assert.NoError(err)
+	assert.Length(diff.Differences(), 6)
+
+	first = []byte(`"foo"`)
+	diff, err = gjp.Compare(first, second)
+	assert.NoError(err)
+	assert.Length(diff.Differences(), 4)
+}
+
+// EOF

--- a/document.go
+++ b/document.go
@@ -15,8 +15,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-
-	"tideland.dev/go/matcher"
 )
 
 //--------------------
@@ -81,146 +79,24 @@ func (d *Document) ValueAt(path string) *PathValue {
 	}
 	node, err := valueAt(d.root, splitPath(path))
 	if err != nil {
-		pv.err = fmt.Errorf("cannot find value at %q: %v", path, err)
+		pv.err = fmt.Errorf("invalid path %q: %v", path, err)
 	} else {
 		pv.node = node
 	}
 	return pv
 }
 
+// Root returns the root path value.
+func (d *Document) Root() *PathValue {
+	return &PathValue{
+		path: Separator,
+		node: d.root,
+	}
+}
+
 // Clear removes the document data.
 func (d *Document) Clear() {
 	d.root = nil
-}
-
-// Query allows to find pathes matching a given pattern.
-func (d *Document) Query(pattern string) (PathValues, error) {
-	pvs := PathValues{}
-	err := d.Process(func(pv *PathValue) error {
-		if matcher.Matches(pattern, pv.path, false) {
-			pvs = append(pvs, &PathValue{
-				path: pv.path,
-				node: pv.node,
-			})
-		}
-		return nil
-	})
-	return pvs, err
-}
-
-// Process iterates recursively over a document and processes all
-// its values.
-func (d *Document) Process(processor Processor) error {
-	return d.process(d.root, []string{}, processor)
-}
-
-// ProcessPath iterates recursively over a document starting at the
-// given path and processes all its values.
-func (d *Document) ProcessPath(path string, processor Processor) error {
-	keys := splitPath(path)
-	node, err := valueAt(d.root, keys)
-	if err != nil {
-		return fmt.Errorf("cannot process path %q: %v", path, err)
-	}
-	return d.process(node, keys, processor)
-}
-
-// process is the internal recursive function for processing.
-func (d *Document) process(node Node, keys []string, process Processor) error {
-	switch tnode := node.(type) {
-	case Object:
-		// A JSON object.
-		if len(tnode) == 0 {
-			return process(&PathValue{
-				path: pathify(keys),
-				node: Object{},
-			})
-		}
-		for key, subnode := range tnode {
-			objectKeys := append(keys, key)
-			if err := d.process(subnode, objectKeys, process); err != nil {
-				return fmt.Errorf("cannot process %q: %v", pathify(objectKeys), err)
-			}
-		}
-	case Array:
-		// A JSON array.
-		if len(tnode) == 0 {
-			return process(&PathValue{
-				path: pathify(keys),
-				node: Array{},
-			})
-		}
-		for idx, subnode := range tnode {
-			arrayKeys := append(keys, strconv.Itoa(idx))
-			if err := d.process(subnode, arrayKeys, process); err != nil {
-				return fmt.Errorf("cannot process %q: %v", pathify(arrayKeys), err)
-			}
-		}
-	default:
-		// A single value at the end.
-		err := process(&PathValue{
-			path: pathify(keys),
-			node: tnode,
-		})
-		if err != nil {
-			return fmt.Errorf("cannot process %q: %v", pathify(keys), err)
-		}
-	}
-	return nil
-}
-
-// Range iterates over the node addressed by the given path and using
-// the processor for each value. It is not working recursively. In
-// case of an object all keys and in case of an array all indices will
-// be processed. In case of a value the processor will be called only
-// once.
-func (d *Document) Range(path string, process Processor) error {
-	node, err := valueAt(d.root, splitPath(path))
-	if err != nil {
-		return fmt.Errorf("cannot find value at %q: %v", path, err)
-	}
-	switch tnode := node.(type) {
-	case Object:
-		// A JSON object.
-		for key := range tnode {
-			keypath := path + Separator + key
-			if isObjectOrArray(tnode[key]) {
-				return fmt.Errorf("cannot process %q: is object or array", keypath)
-			}
-			err := process(&PathValue{
-				path: keypath,
-				node: tnode[key],
-			})
-			if err != nil {
-				return fmt.Errorf("cannot process %q: %v", keypath, err)
-			}
-		}
-	case Array:
-		// A JSON array.
-		for idx := range tnode {
-			idxpath := path + Separator + strconv.Itoa(idx)
-			if isObjectOrArray(tnode[idx]) {
-				return fmt.Errorf("cannot process %q: is object or array", idxpath)
-			}
-			err := process(&PathValue{
-				path: idxpath,
-				node: tnode[idx],
-			})
-			if err != nil {
-				return fmt.Errorf("cannot process %q: %v", idxpath, err)
-			}
-		}
-	default:
-		// A single value at the end.
-		err := process(&PathValue{
-			path: path,
-			node: tnode,
-		})
-		if err != nil {
-			return fmt.Errorf("cannot process %q: %v", path, err)
-		}
-	}
-	return nil
 }
 
 // MarshalJSON implements json.Marshaler.

--- a/gjp.go
+++ b/gjp.go
@@ -24,6 +24,16 @@ const (
 // TYPES
 //--------------------
 
+// Path represents a path in a JSON document. It is a string using
+// the Separator as separator between the keys and indices.
+type Path = string
+
+// Key represents a key or string index in a JSON object.
+type Key = string
+
+// Keys represents a list of keys.
+type Keys = []Key
+
 // Node may be a JSON object, array or value.
 type Node = any
 

--- a/gjp_test.go
+++ b/gjp_test.go
@@ -32,7 +32,7 @@ func TestBuilding(t *testing.T) {
 	// Most simple document.
 	doc := gjp.NewDocument()
 	err := doc.SetValueAt("", "foo")
-	assert.Nil(err)
+	assert.NoError(err)
 
 	sv := doc.ValueAt("").AsString("bar")
 	assert.Equal(sv, "foo")
@@ -40,17 +40,17 @@ func TestBuilding(t *testing.T) {
 	// Positive cases.
 	doc = gjp.NewDocument()
 	err = doc.SetValueAt("/a/b/x", 1)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = doc.SetValueAt("/a/b/y", true)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = doc.SetValueAt("/a/c", "quick brown fox")
-	assert.Nil(err)
+	assert.NoError(err)
 	err = doc.SetValueAt("/a/d/0/z", 47.11)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = doc.SetValueAt("/a/d/1/z", nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = doc.SetValueAt("/a/d/2", 2)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	iv := doc.ValueAt("a/b/x").AsInt(0)
 	assert.Equal(iv, 1)
@@ -63,8 +63,8 @@ func TestBuilding(t *testing.T) {
 	nv := doc.ValueAt("a/d/1/z").IsUndefined()
 	assert.True(nv)
 
-	pvs, err := doc.Query("*x")
-	assert.Nil(err)
+	pvs, err := doc.Root().Query("*x")
+	assert.NoError(err)
 	assert.Length(pvs, 1)
 
 	// Now provoke errors.
@@ -87,7 +87,7 @@ func TestBuilding(t *testing.T) {
 
 	// Legal change of values.
 	err = doc.SetValueAt("/a/b/x", 2)
-	assert.Nil(err)
+	assert.NoError(err)
 	iv = doc.ValueAt("a/b/x").AsInt(0)
 	assert.Equal(iv, 2)
 }
@@ -100,7 +100,7 @@ func TestParseError(t *testing.T) {
 
 	doc, err := gjp.Unmarshal(bs)
 	assert.Nil(doc)
-	assert.ErrorMatch(err, `.*cannot unmarshal document.*`)
+	assert.ErrorContains(err, "cannot unmarshal document")
 }
 
 // TestClear tests to clear a document.
@@ -109,7 +109,7 @@ func TestClear(t *testing.T) {
 	bs, _ := createDocument(assert)
 
 	doc, err := gjp.Unmarshal(bs)
-	assert.Nil(err)
+	assert.NoError(err)
 	doc.Clear()
 	err = doc.SetValueAt("/", "foo")
 	assert.NoError(err)
@@ -123,7 +123,7 @@ func TestLength(t *testing.T) {
 	bs, _ := createDocument(assert)
 
 	doc, err := gjp.Unmarshal(bs)
-	assert.Nil(err)
+	assert.NoError(err)
 	l := doc.Length("X")
 	assert.Equal(l, -1)
 	l = doc.Length("")
@@ -146,13 +146,13 @@ func TestNotFound(t *testing.T) {
 	bs, _ := createDocument(assert)
 
 	doc, err := gjp.Unmarshal(bs)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// Check if is undefined.
 	pv := doc.ValueAt("you-wont-find-me")
 	assert.False(pv.IsUndefined())
 	assert.True(pv.IsError())
-	assert.ErrorContains(pv.Err(), `cannot find value at "you-wont-find-me"`)
+	assert.ErrorContains(pv.Err(), "invalid path")
 }
 
 // TestString verifies the string representation of a document.
@@ -161,7 +161,7 @@ func TestString(t *testing.T) {
 	bs, _ := createDocument(assert)
 
 	doc, err := gjp.Unmarshal(bs)
-	assert.Nil(err)
+	assert.NoError(err)
 	s := doc.String()
 	assert.Equal(s, string(bs))
 }
@@ -172,7 +172,7 @@ func TestAsString(t *testing.T) {
 	bs, _ := createDocument(assert)
 
 	doc, err := gjp.Unmarshal(bs)
-	assert.Nil(err)
+	assert.NoError(err)
 	sv := doc.ValueAt("A").AsString("default")
 	assert.Equal(sv, "Level One")
 	sv = doc.ValueAt("B/0/B").AsString("default")
@@ -189,7 +189,7 @@ func TestAsString(t *testing.T) {
 	sv = doc.ValueAt("Z/Z/Z").String()
 
 	// Difference between invalid path and nil value.
-	assert.Contains("cannot find value at", sv)
+	assert.Contains("invalid path", sv)
 	doc.SetValueAt("Z/Z/Z", nil)
 	sv = doc.ValueAt("Z/Z/Z").String()
 	assert.Equal(sv, "null")
@@ -201,7 +201,7 @@ func TestAsInt(t *testing.T) {
 	bs, _ := createDocument(assert)
 
 	doc, err := gjp.Unmarshal(bs)
-	assert.Nil(err)
+	assert.NoError(err)
 	iv := doc.ValueAt("A").AsInt(-1)
 	assert.Equal(iv, -1)
 	iv = doc.ValueAt("B/0/B").AsInt(-1)
@@ -222,7 +222,7 @@ func TestAsFloat64(t *testing.T) {
 	bs, _ := createDocument(assert)
 
 	doc, err := gjp.Unmarshal(bs)
-	assert.Nil(err)
+	assert.NoError(err)
 	fv := doc.ValueAt("A").AsFloat64(-1.0)
 	assert.Equal(fv, -1.0)
 	fv = doc.ValueAt("B/0/B").AsFloat64(-1.0)
@@ -245,7 +245,7 @@ func TestAsBool(t *testing.T) {
 	bs, _ := createDocument(assert)
 
 	doc, err := gjp.Unmarshal(bs)
-	assert.Nil(err)
+	assert.NoError(err)
 	bv := doc.ValueAt("A").AsBool(false)
 	assert.Equal(bv, false)
 	bv = doc.ValueAt("B/0/C").AsBool(false)
@@ -260,44 +260,6 @@ func TestAsBool(t *testing.T) {
 	assert.Equal(bv, false)
 }
 
-// TestQuery tests querying a document.
-func TestQuery(t *testing.T) {
-	assert := asserts.NewTesting(t, asserts.FailStop)
-	bs, _ := createDocument(assert)
-
-	doc, err := gjp.Unmarshal(bs)
-	assert.Nil(err)
-	pvs, err := doc.Query("Z/*")
-	assert.Nil(err)
-	assert.Length(pvs, 0)
-	pvs, err = doc.Query("*")
-	assert.Nil(err)
-	assert.Length(pvs, 27)
-	pvs, err = doc.Query("/A")
-	assert.Nil(err)
-	assert.Length(pvs, 1)
-	pvs, err = doc.Query("/B/*")
-	assert.Nil(err)
-	assert.Length(pvs, 24)
-	pvs, err = doc.Query("/B/[01]/*")
-	assert.Nil(err)
-	assert.Length(pvs, 18)
-	pvs, err = doc.Query("/B/[01]/*A")
-	assert.Nil(err)
-	assert.Length(pvs, 4)
-	pvs, err = doc.Query("*/S/*")
-	assert.Nil(err)
-	assert.Length(pvs, 8)
-	pvs, err = doc.Query("*/S/3")
-	assert.Nil(err)
-	assert.Length(pvs, 1)
-
-	pvs, err = doc.Query("/A")
-	assert.Nil(err)
-	assert.Equal(pvs[0].Path(), "/A")
-	assert.Equal(pvs[0].AsString(""), "Level One")
-}
-
 // TestMarshalJSON tests building a JSON document again.
 func TestMarshalJSON(t *testing.T) {
 	assert := asserts.NewTesting(t, asserts.FailStop)
@@ -305,20 +267,20 @@ func TestMarshalJSON(t *testing.T) {
 	// Compare input and output.
 	bsIn, _ := createDocument(assert)
 	parsedDoc, err := gjp.Unmarshal(bsIn)
-	assert.Nil(err)
+	assert.NoError(err)
 	bsOut, err := parsedDoc.MarshalJSON()
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal(bsOut, bsIn)
 
 	// Now create a built one.
 	builtDoc := gjp.NewDocument()
 	err = builtDoc.SetValueAt("/a/2/x", 1)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = builtDoc.SetValueAt("/a/4/y", true)
-	assert.Nil(err)
+	assert.NoError(err)
 	bsIn = []byte(`{"a":[null,null,{"x":1},null,{"y":true}]}`)
 	bsOut, err = builtDoc.MarshalJSON()
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal(bsOut, bsIn)
 }
 
@@ -394,7 +356,7 @@ func createDocument(assert *asserts.Asserts) ([]byte, *levelOne) {
 		T: time.Date(2018, time.April, 29, 20, 30, 0, 0, time.UTC),
 	}
 	bs, err := json.Marshal(lo)
-	assert.Nil(err)
+	assert.NoError(err)
 	return bs, lo
 }
 
@@ -438,7 +400,7 @@ func createCompareDocument(assert *asserts.Asserts) []byte {
 		T: time.Date(2018, time.April, 29, 20, 59, 0, 0, time.UTC),
 	}
 	bs, err := json.Marshal(lo)
-	assert.Nil(err)
+	assert.NoError(err)
 	return bs
 }
 

--- a/path.go
+++ b/path.go
@@ -21,25 +21,25 @@ import (
 // PROCESSING FUNCTIONS
 //--------------------
 
-// splitPath splits and cleans the path into parts.
-func splitPath(path string) []string {
-	parts := strings.Split(path, Separator)
+// splitPath splits and cleans the path into keys.
+func splitPath(path Path) Keys {
+	keys := strings.Split(path, Separator)
 	out := []string{}
-	for _, part := range parts {
-		if part != "" {
-			out = append(out, part)
+	for _, key := range keys {
+		if key != "" {
+			out = append(out, key)
 		}
 	}
 	return out
 }
 
 // ht retrieves head and tail from a list of keys.
-func ht(keys []string) (string, []string) {
+func ht(keys Keys) (Key, Keys) {
 	switch len(keys) {
 	case 0:
-		return "", []string{}
+		return "", Keys{}
 	case 1:
-		return keys[0], []string{}
+		return keys[0], Keys{}
 	default:
 		return keys[0], keys[1:]
 	}
@@ -66,7 +66,7 @@ func isValue(node Node) bool {
 }
 
 // valueAt returns the value at the given path.
-func valueAt(node Node, keys []string) (Node, error) {
+func valueAt(node Node, keys Keys) (Node, error) {
 	if len(keys) == 0 {
 		// End of the path.
 		return node, nil
@@ -97,8 +97,17 @@ func valueAt(node Node, keys []string) (Node, error) {
 }
 
 // pathify creates a path out of keys.
-func pathify(parts []string) string {
-	return Separator + strings.Join(parts, Separator)
+func pathify(keys Keys) Path {
+	return Separator + strings.Join(keys, Separator)
+}
+
+// appendKey appends a key to a path.
+func appendKey(path Path, key Key) Path {
+	if len(path) == 1 {
+		// Root path.
+		return path + key
+	}
+	return path + Separator + key
 }
 
 // EOF

--- a/path.go
+++ b/path.go
@@ -101,47 +101,4 @@ func pathify(parts []string) string {
 	return Separator + strings.Join(parts, Separator)
 }
 
-// process processes node recursively.
-func process(node any, keys []string, processor ValueProcessor) error {
-	mkerr := func(err error, ps []string) error {
-		return fmt.Errorf("cannot process '%s': %v", pathify(ps), err)
-	}
-
-	switch tnode := node.(type) {
-	case Object:
-		// A JSON object.
-		if len(tnode) == 0 {
-			return (&PathValue{
-				path: pathify(keys),
-			}).Process(processor)
-		}
-		for key, subnode := range tnode {
-			objectKeys := append(keys, key)
-			if err := process(subnode, objectKeys, processor); err != nil {
-				return mkerr(err, keys)
-			}
-		}
-	case Array:
-		// A JSON array.
-		if len(tnode) == 0 {
-			return (&PathValue{
-				path: pathify(keys),
-			}).Process(processor)
-		}
-		for index, subnode := range tnode {
-			arrayKeys := append(keys, strconv.Itoa(index))
-			if err := process(subnode, arrayKeys, processor); err != nil {
-				return mkerr(err, keys)
-			}
-		}
-	default:
-		// A single value at the end.
-		return (&PathValue{
-			path: pathify(keys),
-			node: tnode,
-		}).Process(processor)
-	}
-	return nil
-}
-
 // EOF

--- a/process_test.go
+++ b/process_test.go
@@ -1,0 +1,152 @@
+// Tideland Go Generic JSON Processor - Unit Tests
+//
+// Copyright (C) 2019-2023 Frank Mueller / Tideland / Oldenburg / Germany
+//
+// All rights reserved. Use of this source code is governed
+// by the new BSD license.
+
+package gjp_test
+
+//--------------------
+// IMPORTS
+//--------------------
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"tideland.dev/go/audit/asserts"
+
+	"tideland.dev/go/gjp"
+)
+
+//--------------------
+// TESTS
+//--------------------
+
+// TestProcess tests the processing of documents.
+func TestProcess(t *testing.T) {
+	assert := asserts.NewTesting(t, asserts.FailStop)
+	bs, _ := createDocument(assert)
+
+	values := []string{}
+	processor := func(pv *gjp.PathValue) error {
+		value := fmt.Sprintf("%q = %q", pv.Path(), pv.AsString("<undefined>"))
+		values = append(values, value)
+		return nil
+	}
+	doc, err := gjp.Unmarshal(bs)
+	assert.NoError(err)
+
+	// Verify iteration of all nodes.
+	err = doc.Process(processor)
+	assert.NoError(err)
+	assert.Length(values, 27)
+	assert.Contains(`"/B/0/B" = "100"`, values)
+	assert.Contains(`"/B/0/C" = "true"`, values)
+	assert.Contains(`"/B/1/S/2" = "white"`, values)
+
+	// Verifiy processing error.
+	processor = func(pv *gjp.PathValue) error {
+		return errors.New("ouch")
+	}
+	err = doc.Process(processor)
+	assert.ErrorContains(err, "ouch")
+}
+
+// TestProcessPath tests the processing of documents starting at a path.
+func TestProcessPath(t *testing.T) {
+	assert := asserts.NewTesting(t, asserts.FailStop)
+	bs, _ := createDocument(assert)
+
+	values := []string{}
+	processor := func(pv *gjp.PathValue) error {
+		value := fmt.Sprintf("%q = %q", pv.Path(), pv.AsString("<undefined>"))
+		values = append(values, value)
+		return nil
+	}
+	doc, err := gjp.Unmarshal(bs)
+	assert.NoError(err)
+
+	// Verify iteration of all nodes.
+	err = doc.ProcessPath("/B/0/D", processor)
+	assert.NoError(err)
+	assert.Length(values, 2)
+	assert.Contains(`"/B/0/D/A" = "Level Three - 0"`, values)
+	assert.Contains(`"/B/0/D/B" = "10.1"`, values)
+
+	values = []string{}
+	err = doc.ProcessPath("/B/1", processor)
+	assert.NoError(err)
+	assert.Length(values, 8)
+	assert.Contains(`"/B/1/S/2" = "white"`, values)
+	assert.Contains(`"/B/1/B" = "200"`, values)
+
+	// Verifiy iteration of non-existing path.
+	err = doc.ProcessPath("/B/3", processor)
+	assert.ErrorContains(err, "invalid path")
+
+	// Verify procesing error.
+	processor = func(pv *gjp.PathValue) error {
+		return errors.New("ouch")
+	}
+	err = doc.ProcessPath("/A", processor)
+	assert.ErrorContains(err, "ouch")
+}
+
+// TestRange tests the range processing of documents.
+func TestRange(t *testing.T) {
+	assert := asserts.NewTesting(t, asserts.FailStop)
+	bs, _ := createDocument(assert)
+
+	values := []string{}
+	processor := func(pv *gjp.PathValue) error {
+		value := fmt.Sprintf("%q = %q", pv.Path(), pv.AsString("<undefined>"))
+		values = append(values, value)
+		return nil
+	}
+	doc, err := gjp.Unmarshal(bs)
+	assert.NoError(err)
+
+	// Verify range of object.
+	values = []string{}
+	err = doc.Range("/B/0/D", processor)
+	assert.NoError(err)
+	assert.Length(values, 2)
+	assert.Contains(`"/B/0/D/A" = "Level Three - 0"`, values)
+	assert.Contains(`"/B/0/D/B" = "10.1"`, values)
+
+	// Verify range of array.
+	values = []string{}
+	err = doc.Range("/B/1/S", processor)
+	assert.NoError(err)
+	assert.Length(values, 3)
+	assert.Contains(`"/B/1/S/0" = "orange"`, values)
+	assert.Contains(`"/B/1/S/1" = "blue"`, values)
+	assert.Contains(`"/B/1/S/2" = "white"`, values)
+
+	// Verify range of value.
+	values = []string{}
+	err = doc.Range("/A", processor)
+	assert.NoError(err)
+	assert.Length(values, 1)
+	assert.Contains(`"/A" = "Level One"`, values)
+
+	// Verify range of non-existing path.
+	err = doc.Range("/B/0/D/X", processor)
+	assert.ErrorContains(err, "invalid path")
+
+	// Verify range of mixed types.
+	err = doc.Range("/B/0", processor)
+	assert.ErrorContains(err, "is object or array")
+
+	// Verify procesing error.
+	processor = func(pv *gjp.PathValue) error {
+		return errors.New("ouch")
+	}
+	err = doc.Range("/A", processor)
+	assert.ErrorContains(err, "ouch")
+}
+
+// EOF

--- a/value.go
+++ b/value.go
@@ -15,6 +15,9 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
+
+	"tideland.dev/go/matcher"
 )
 
 //--------------------
@@ -28,7 +31,7 @@ type Processor func(pv *PathValue) error
 
 // PathValue is the combination of path and its node value.
 type PathValue struct {
-	path string
+	path Path
 	node Node
 	err  error
 }
@@ -150,19 +153,139 @@ func (pv *PathValue) Equals(to *PathValue) bool {
 	}
 }
 
-// Process processes the value with the passed processor.
-func (pv *PathValue) Process(process Processor) error {
-	return process(pv)
-}
-
 // Path returns the path of the value.
-func (pv *PathValue) Path() string {
+func (pv *PathValue) Path() Path {
 	return pv.path
 }
 
 // SplitPath splits the path into its keys.
-func (pv *PathValue) SplitPath() []string {
+func (pv *PathValue) SplitPath() Keys {
 	return splitPath(pv.path)
+}
+
+// Process iterates over the node and all its subnodes and
+// processes them with the passed processor function.
+func (pv *PathValue) Process(process Processor) error {
+	if pv.err != nil {
+		return pv.err
+	}
+	switch tnode := pv.node.(type) {
+	case Object:
+		// A JSON object.
+		if len(tnode) == 0 {
+			return process(&PathValue{
+				path: pv.path,
+				node: Object{},
+			})
+		}
+		for key, subnode := range tnode {
+			subpath := appendKey(pv.path, key)
+			subvalue := &PathValue{
+				path: subpath,
+				node: subnode,
+			}
+			if err := subvalue.Process(process); err != nil {
+				return fmt.Errorf("cannot process %q: %v", subpath, err)
+			}
+		}
+	case Array:
+		// A JSON array.
+		if len(tnode) == 0 {
+			return process(&PathValue{
+				path: pv.path,
+				node: Array{},
+			})
+		}
+		for idx, subnode := range tnode {
+			subpath := appendKey(pv.path, strconv.Itoa(idx))
+			subvalue := &PathValue{
+				path: subpath,
+				node: subnode,
+			}
+			if err := subvalue.Process(process); err != nil {
+				return fmt.Errorf("cannot process %q: %v", subpath, err)
+			}
+		}
+	default:
+		// A single value at the end.
+		err := process(&PathValue{
+			path: pv.path,
+			node: tnode,
+		})
+		if err != nil {
+			return fmt.Errorf("cannot process %q: %v", pv.path, err)
+		}
+	}
+	return nil
+}
+
+// Range takes  the node and processes it with the passed processor
+// function. In case of an object all keys and in case of an array
+// all indices will be processed. It is not working recursively.
+func (pv *PathValue) Range(process Processor) error {
+	if pv.err != nil {
+		return pv.err
+	}
+	switch tnode := pv.node.(type) {
+	case Object:
+		// A JSON object.
+		for key := range tnode {
+			keypath := appendKey(pv.path, key)
+			if isObjectOrArray(tnode[key]) {
+				return fmt.Errorf("cannot process %q: is object or array", keypath)
+			}
+			err := process(&PathValue{
+				path: keypath,
+				node: tnode[key],
+			})
+			if err != nil {
+				return fmt.Errorf("cannot process %q: %v", keypath, err)
+			}
+		}
+	case Array:
+		// A JSON array.
+		for idx := range tnode {
+			idxpath := appendKey(pv.path, strconv.Itoa(idx))
+			if isObjectOrArray(tnode[idx]) {
+				return fmt.Errorf("cannot process %q: is object or array", idxpath)
+			}
+			err := process(&PathValue{
+				path: idxpath,
+				node: tnode[idx],
+			})
+			if err != nil {
+				return fmt.Errorf("cannot process %q: %v", idxpath, err)
+			}
+		}
+	default:
+		// A single value at the end.
+		err := process(&PathValue{
+			path: pv.path,
+			node: tnode,
+		})
+		if err != nil {
+			return fmt.Errorf("cannot process %q: %v", pv.path, err)
+		}
+	}
+	return nil
+}
+
+// Query iterates over the node and all its subnodes and returns
+// all values with paths matching the passed pattern.
+func (pv *PathValue) Query(pattern string) (PathValues, error) {
+	pvs := PathValues{}
+	err := pv.Process(func(ppv *PathValue) error {
+		ppvpath := strings.TrimPrefix(ppv.path, pv.path+Separator)
+		println(pattern + "  =>  " + ppvpath)
+		if matcher.Matches(pattern, ppvpath, false) {
+			pvs = append(pvs, &PathValue{
+				path: ppv.path,
+				node: ppv.node,
+			})
+		}
+		return nil
+	})
+	return pvs, err
 }
 
 // String implements fmt.Stringer.

--- a/value.go
+++ b/value.go
@@ -21,9 +21,10 @@ import (
 // PATH VALUE
 //--------------------
 
-// ValueProcessor describes a function for the processing of
-// values while iterating over a document.
-type ValueProcessor func(pv *PathValue) error
+// Processor defines the signature of function for processing
+// a path value. This may be the iterating over the whole
+// document or one object or array.
+type Processor func(pv *PathValue) error
 
 // PathValue is the combination of path and its node value.
 type PathValue struct {
@@ -150,7 +151,7 @@ func (pv *PathValue) Equals(to *PathValue) bool {
 }
 
 // Process processes the value with the passed processor.
-func (pv *PathValue) Process(process ValueProcessor) error {
+func (pv *PathValue) Process(process Processor) error {
 	return process(pv)
 }
 


### PR DESCRIPTION
Handles #5 

Opposite to initial idea add it to `PathValue`. Also move `Process()` and `Query()` to `PathValue`. For access from root added `Root() *PathValue` to `Document`.